### PR TITLE
RTAB-Map dual camera support and RViz2 launch with custom config and coordinate integration into depth estimation node

### DIFF
--- a/src/control_system/control_system/allocation_matrix.py
+++ b/src/control_system/control_system/allocation_matrix.py
@@ -11,18 +11,18 @@ class ThrusterMixer(Node):
         super().__init__('thruster_mixer')
 
         # Geometry (meters)
-        W = 0.35
+        W = 0.275
         Lf = 0.30
-        Lr = 0.30
+        Lr = 0.375
 
         # Build full 6x5 configuration matrix B
         self.B = np.array([
-            [-1,   -1,   0,    0,    0],     # Fx
+            [1,   1,   0,    0,    0],     # Fx
             [0,   0,   0,    0,    0],     # Fy (no sway authority)
-            [0,   0,  -1,   -1,   -1],     # Fz
+            [0,   0,  -20,   -20,   -20],     # Fz
             [0,   0,   W,   -W,    0],     # τx (roll)
             [0,   0,   Lf,   Lf,  -Lr],    # τy (pitch)
-            [-W,  W,   0,    0,    0],     # τz (yaw)
+            [W,  -W,   0,    0,    0],     # τz (yaw)
         ], dtype=float)
 
         # Precompute pseudoinverse

--- a/src/hydrogen/hydrogen/data_distance_node.py
+++ b/src/hydrogen/hydrogen/data_distance_node.py
@@ -4,21 +4,104 @@ import rclpy
 from rclpy.node import Node
 from rclpy.parameter import Parameter
 from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+from rclpy.duration import Duration
 
 from sensor_msgs.msg import Image, CameraInfo
 from vision_msgs.msg import Detection2DArray, Detection3DArray, Detection3D, ObjectHypothesisWithPose
-from geometry_msgs.msg import Pose, Point, Quaternion
+from geometry_msgs.msg import Pose, Point, Quaternion, PointStamped
 
 from cv_bridge import CvBridge
 import numpy as np
 import cv2
 
 from message_filters import Subscriber, ApproximateTimeSynchronizer
-
 from ultralytics.utils.plotting import colors
+
+import tf2_ros
+import tf2_geometry_msgs  # registers PointStamped with tf2; must be imported even if unused directly
+from tf2_ros import LookupException, ConnectivityException, ExtrapolationException
+
+
+CLASS_NAMES = {
+    "0":  "left_gate_pole",
+    "1":  "right_gate_pole",
+    "2":  "shark",
+    "3":  "sawfish",
+    "4":  "drop_box",
+    "5":  "red_buoy",
+    "6":  "red_pole",
+    "7":  "white_pole",
+    "8":  "path_marker",
+    "9":  "octagon",
+    "10": "table",
+    "11": "ladle",
+    "12": "bottle",
+}
+
+FONT           = cv2.FONT_HERSHEY_SIMPLEX
+FONT_SCALE     = 0.5
+FONT_THICKNESS = 1
+COLOR_WHITE    = (255, 255, 255)
+COLOR_BLACK    = (0, 0, 0)
+COLOR_GREEN    = (0, 255, 0)
+
+
+def draw_detection(img, xmin, ymin, xmax, ymax, u_obj, v_obj,
+                   name, color, z, x_odom, y_odom, z_odom):
+    """
+    Draws all per-detection annotations onto the image in place.
+    Keeps the label, depth, centroid, and coordinate overlay visually grouped.
+    """
+    # Bounding box
+    cv2.rectangle(img, (xmin, ymin), (xmax, ymax), color, 2)
+
+    # Class label + depth above the box
+    label = f"{name}  {z:.2f}m"
+    (lw, lh), _ = cv2.getTextSize(label, FONT, FONT_SCALE, FONT_THICKNESS)
+    label_y = max(ymin - 6, lh + 6)
+    cv2.rectangle(img, (xmin, label_y - lh - 4), (xmin + lw + 6, label_y + 4), color, -1)
+    cv2.putText(img, label, (xmin + 3, label_y), FONT, FONT_SCALE, COLOR_BLACK, FONT_THICKNESS)
+
+    # Centroid dot
+    cv2.circle(img, (u_obj, v_obj), 4, COLOR_GREEN, -1)
+
+    # Coordinate overlay — shown as a small pill anchored to the centroid
+    coord_lines = [
+        f"x {x_odom:+.2f}",
+        f"y {y_odom:+.2f}",
+        f"z {z_odom:+.2f}",
+    ]
+    line_h      = 18
+    padding     = 6
+    box_w       = 80
+    box_h       = line_h * len(coord_lines) + padding * 2
+
+    # Anchor the box to the right of the centroid, nudge it inward if it would clip the edge
+    bx = min(u_obj + 10, img.shape[1] - box_w - 4)
+    by = max(v_obj - box_h // 2, 4)
+    by = min(by, img.shape[0] - box_h - 4)
+
+    # Semi-transparent dark background
+    overlay = img.copy()
+    cv2.rectangle(overlay, (bx, by), (bx + box_w, by + box_h), (20, 20, 20), -1)
+    cv2.addWeighted(overlay, 0.6, img, 0.4, 0, img)
+
+    # Thin border in the detection color
+    cv2.rectangle(img, (bx, by), (bx + box_w, by + box_h), color, 1)
+
+    for i, line in enumerate(coord_lines):
+        ty = by + padding + (i + 1) * line_h - 4
+        cv2.putText(img, line, (bx + padding, ty), FONT, 0.42, COLOR_WHITE, 1)
 
 
 class ROIDepthFusion(Node):
+    """
+    Subscribes to synchronized RGB, depth, and 2D detection streams.
+    For each detection, crops the depth ROI, estimates the object's 3D
+    position via pinhole projection, transforms it into the odom frame,
+    and publishes a Detection3DArray. Also publishes an annotated image
+    for visualization in RViz.
+    """
 
     def __init__(self):
         super().__init__('roi_depth_fusion_node')
@@ -27,7 +110,6 @@ class ROIDepthFusion(Node):
             Parameter('use_sim_time', Parameter.Type.BOOL, True)
         ])
 
-        # Parameters
         self.declare_parameter('min_depth', 0.2)
         self.declare_parameter('max_depth', 20.0)
         self.declare_parameter('min_valid_pixels', 30)
@@ -36,80 +118,62 @@ class ROIDepthFusion(Node):
         self.max_depth = self.get_parameter('max_depth').value
         self.min_valid = self.get_parameter('min_valid_pixels').value
 
-        self.bridge = CvBridge()
+        self.bridge      = CvBridge()
         self.camera_info = None
 
-        self.class_names = {
-            "0": "left_gate_pole",
-            "1": "right_gate_pole",
-            "2": "shark",
-            "3": "sawfish",
-            "4": "drop_box",
-            "5": "red_buoy",
-            "6": "red_pole",
-            "7": "white_pole",
-            "8": "path_marker",
-            "9": "octagon",
-            "10": "table",
-            "11": "ladle",
-            "12": "bottle"
-        }
+        # 10s TF cache to handle cases where the transform arrives slightly late
+        self.tf_buffer   = tf2_ros.Buffer(cache_time=Duration(seconds=10))
+        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
 
         self.depth_sub = Subscriber(self, Image, '/camera/depth_image_raw/front')
         self.rgb_sub   = Subscriber(self, Image, '/camera/RGB_image_raw/front')
         self.det_sub   = Subscriber(self, Detection2DArray, '/detections_2d')
 
         self.info_sub = self.create_subscription(
-            CameraInfo,
-            '/camera_info_front',
-            self.camera_info_cb,
-            10
+            CameraInfo, '/camera_info_front', self.camera_info_cb, 10
         )
 
+        # slop=0.2s tolerates the typical latency between camera capture and detector output
         self.sync = ApproximateTimeSynchronizer(
             [self.depth_sub, self.rgb_sub, self.det_sub],
             queue_size=10,
-            slop=0.2
+            slop=0.2,
         )
         self.sync.registerCallback(self.synced_cb)
 
-        self.pub = self.create_publisher(
-            Detection3DArray,
-            '/detections_3d',
-            10
+        self.pub = self.create_publisher(Detection3DArray, '/detections_3d', 10)
+        self.viz_pub = self.create_publisher(
+            Image,
+            '/depth_fusion/detection_image',
+            QoSProfile(
+                reliability=ReliabilityPolicy.RELIABLE,
+                history=HistoryPolicy.KEEP_LAST,
+                depth=10,
+                durability=DurabilityPolicy.VOLATILE,
+            ),
         )
-
-        
-        qos = QoSProfile(
-            reliability=ReliabilityPolicy.RELIABLE,
-            history=HistoryPolicy.KEEP_LAST,
-            depth=10,
-            durability=DurabilityPolicy.VOLATILE
-        )
-        self.viz_pub = self.create_publisher(Image, '/depth_fusion/detection_image', qos)
 
         self.get_logger().info("ROI depth fusion node started.")
+
+    # ------------------------------------------------------------------
 
     def camera_info_cb(self, msg: CameraInfo):
         self.camera_info = msg
 
-    def synced_cb(self, depth_msg: Image,
-                  rgb_msg: Image,
-                  det_msg: Detection2DArray):
-
+    def synced_cb(self, depth_msg: Image, rgb_msg: Image, det_msg: Detection2DArray):
         if self.camera_info is None:
-            self.get_logger().warn("Camera info not received yet, skipping processing.")
+            self.get_logger().warn("Camera info not yet received — skipping frame.")
             return
 
         depth_img = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding='32FC1')
-        rgb_img   = self.bridge.imgmsg_to_cv2(rgb_msg, desired_encoding='bgr8')
+        rgb_img   = self.bridge.imgmsg_to_cv2(rgb_msg,   desired_encoding='bgr8')
 
         fx = self.camera_info.k[0]
         fy = self.camera_info.k[4]
         cx = self.camera_info.k[2]
         cy = self.camera_info.k[5]
 
-        out = Detection3DArray()
+        out        = Detection3DArray()
         out.header = det_msg.header
 
         self.get_logger().info(f"Processing {len(det_msg.detections)} detections.")
@@ -118,11 +182,10 @@ class ROIDepthFusion(Node):
             if not det.results:
                 continue
 
-            hyp = det.results[0].hypothesis
+            hyp      = det.results[0].hypothesis
             class_id = hyp.class_id
-            score = hyp.score
-
-            bbox = det.bbox
+            score    = hyp.score
+            bbox     = det.bbox
 
             u = int(bbox.center.position.x)
             v = int(bbox.center.position.y)
@@ -134,32 +197,70 @@ class ROIDepthFusion(Node):
             ymin = max(v - h // 2, 0)
             ymax = min(v + h // 2, depth_img.shape[0] - 1)
 
-            roi = depth_img[ymin:ymax, xmin:xmax].flatten()
-            roi = roi[np.isfinite(roi)]
-            roi = roi[(roi > self.min_depth) & (roi < self.max_depth)]
+            roi        = depth_img[ymin:ymax, xmin:xmax]
+            valid_mask = np.isfinite(roi) & (roi > self.min_depth) & (roi < self.max_depth)
 
-            if roi.size < self.min_valid:
+            if np.count_nonzero(valid_mask) < self.min_valid:
                 continue
 
-            z = float(np.median(roi))
+            # Histogram over valid depths to isolate the foreground cluster.
+            # Without this, background pixels inside the bbox skew the depth estimate.
+            valid_depths = roi[valid_mask]
+            hist, bins   = np.histogram(valid_depths, bins=50)
+            peak_idx     = np.argmax(hist)
+            bin_center   = (bins[peak_idx] + bins[peak_idx + 1]) / 2.0
+            fg_mask      = valid_mask & (roi >= bin_center - 0.3) & (roi <= bin_center + 0.3)
 
-            x = (u - cx) * z / fx
-            y = (v - cy) * z / fy
+            if np.count_nonzero(fg_mask) < self.min_valid:
+                continue
 
-            det3d = Detection3D()
+            ys, xs = np.where(fg_mask)
+            u_obj  = int(np.mean(xs)) + xmin
+            v_obj  = int(np.mean(ys)) + ymin
+
+            # Median is more robust than min here — a single noisy foreground pixel
+            # won't pull the depth estimate closer than the actual object surface.
+            z = float(np.median(roi[fg_mask]))
+            x = (u_obj - cx) * z / fx
+            y = (v_obj - cy) * z / fy
+
+            point_camera                 = PointStamped()
+            point_camera.header.frame_id = 'zed_camera_front_link_optical_frame'
+            point_camera.header.stamp    = depth_msg.header.stamp
+            point_camera.point.x         = x
+            point_camera.point.y         = y
+            point_camera.point.z         = z
+
+            try:
+                point_odom = self.tf_buffer.transform(point_camera, 'odom', timeout=Duration(seconds=1.0))
+                x_odom = point_odom.point.x
+                y_odom = point_odom.point.y
+                z_odom = point_odom.point.z
+            except (LookupException, ConnectivityException, ExtrapolationException) as e:
+                # TF tree not yet populated or extrapolation window missed — use camera frame as fallback
+                self.get_logger().debug(f"TF transform failed: {e} — publishing in camera frame.")
+                x_odom, y_odom, z_odom = x, y, z
+
+            name  = CLASS_NAMES.get(class_id, class_id)
+            color = colors(int(class_id), True)
+
+            draw_detection(rgb_img, xmin, ymin, xmax, ymax,
+                           u_obj, v_obj, name, color,
+                           z, x_odom, y_odom, z_odom)
+
+            det3d        = Detection3D()
             det3d.header = det.header
 
-            hyp3d = ObjectHypothesisWithPose()
+            hyp3d                     = ObjectHypothesisWithPose()
             hyp3d.hypothesis.class_id = class_id
-            hyp3d.hypothesis.score = score
+            hyp3d.hypothesis.score    = score
 
-            pose = Pose()
-            pose.position = Point(x=x, y=y, z=z)
+            pose             = Pose()
+            pose.position    = Point(x=x_odom, y=y_odom, z=z_odom)
             pose.orientation = Quaternion(w=1.0)
+            hyp3d.pose.pose  = pose
 
-            hyp3d.pose.pose = pose
             det3d.results.append(hyp3d)
-
             det3d.bbox.center = pose
             det3d.bbox.size.x = 0.1
             det3d.bbox.size.y = 0.1
@@ -167,19 +268,9 @@ class ROIDepthFusion(Node):
 
             out.detections.append(det3d)
 
-            color = colors(int(class_id), True)
-            cv2.rectangle(rgb_img, (xmin, ymin), (xmax, ymax), color, 2)
-            name = self.class_names.get(class_id, class_id)
-            label = f"{name} {z:.2f} m"
-            cv2.putText(rgb_img, label,
-            (xmin, max(ymin - 10, 15)),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.5, color, 2)
-
         self.pub.publish(out)
 
-        # rviz publisher
-        ros_img = self.bridge.cv2_to_imgmsg(rgb_img, encoding='bgr8')
+        ros_img        = self.bridge.cv2_to_imgmsg(rgb_img, encoding='bgr8')
         ros_img.header = rgb_msg.header
         self.viz_pub.publish(ros_img)
         cv2.imshow("Depth Fusion Detections", rgb_img)

--- a/src/hydrogen/launch/RTAB_map.launch.py
+++ b/src/hydrogen/launch/RTAB_map.launch.py
@@ -10,60 +10,83 @@ def launch_setup(context: LaunchContext, *args, **kwargs):
     
     # 1. Get configuration from arguments
     use_sim_time = LaunchConfiguration('use_sim_time')
-    rgb_topic = LaunchConfiguration('rgb_topic')
-    depth_topic = LaunchConfiguration('depth_topic')
-    camera_info_topic = LaunchConfiguration('camera_info_topic')
+    rgb_topic_front = LaunchConfiguration('rgb_topic_front')
+    depth_topic_front = LaunchConfiguration('depth_topic_front')
+    camera_info_topic_front = LaunchConfiguration('camera_info_topic_front')
+    rgb_topic_down = LaunchConfiguration('rgb_topic_down')
+    depth_topic_down = LaunchConfiguration('depth_topic_down')
+    camera_info_topic_down = LaunchConfiguration('camera_info_topic_down')
     frame_id = LaunchConfiguration('frame_id').perform(context)
     
-    # 2. Define parameters
-    parameters=[{
+    # 2. Defining parameters 
+    base_parameters=[{
         'frame_id': frame_id,
         'subscribe_rgbd': True,
         'subscribe_odom_info': True,
-        'approx_sync': False, # Set to True if sim topics have different timestamps
+        'approx_sync': False, 
         'use_sim_time': use_sim_time,
         'wait_imu_to_init': False # Disabled as most sims don't sync IMU with standard plugins
     }]
-
-    # 3. Define Remappings
-    # These map the rtabmap node inputs to your simulation topics
-    remappings=[
-        ('rgb/image', rgb_topic),
-        ('rgb/camera_info', camera_info_topic),
-        ('depth/image', depth_topic)
-    ]
+    rtbmap_parameters = [{
+        **base_parameters[0],
+        'rgbd_cameras':2,
+        'Vis/EstimationType': '0', 
+    }]    
 
     return [
         # Node 1: Sync rgb/depth/camera_info together
         # This creates an 'rgbd_image' topic that RTAB-Map needs
         Node(   
             package='rtabmap_sync', executable='rgbd_sync', output='screen',
-            parameters=parameters,
-            remappings=remappings
+            name='rgbd_sync_front',
+            parameters=base_parameters,
+            remappings=[
+                ('rgb/image', rgb_topic_front),
+                ('rgb/camera_info', camera_info_topic_front),
+                ('depth/image', depth_topic_front),
+                ('rgbd_image', '/rgbd_image0'), # Output topic for RTAB-Map
+            ]   
         ),
-
+        Node(   
+            package='rtabmap_sync', executable='rgbd_sync', output='screen',
+            name='rgbd_sync_down',
+            parameters=base_parameters,
+            remappings=[
+                ('rgb/image', rgb_topic_down),
+                ('rgb/camera_info', camera_info_topic_down),
+                ('depth/image', depth_topic_down),
+                ('rgbd_image', '/rgbd_image1'), # Output topic for RTAB-  Map
+            ],   
+        ),
         # Node 2: Visual Odometry
         # Computes odometry from the camera images (since we aren't using ZED's internal odom)
         Node(
             package='rtabmap_odom', executable='rgbd_odometry', output='screen',
-            parameters=parameters,
-            remappings=remappings,
+            parameters= base_parameters,
+            remappings=[
+                ('rgbd_image','/rgbd_image0'),
+            ],
             arguments=['--ros-args', '--log-level', 'warn'] # Reduce noise
         ),
-
         # Node 3: RTAB-Map SLAM
         Node(
             package='rtabmap_slam', executable='rtabmap', output='screen',
-            parameters=parameters,
-            remappings=remappings,
+            parameters=rtbmap_parameters,
+            remappings=[
+                ('rgbd_image','/rgbd_image0'),
+                ('rgbd_image2','/rgbd_image1'),
+            ],
             arguments=['-d'] # Delete previous database on start
         ),
 
         # Node 4: Visualization
         Node(
             package='rtabmap_viz', executable='rtabmap_viz', output='screen',
-            parameters=parameters,
-            remappings=remappings
+            parameters=rtbmap_parameters,
+            remappings=[
+                ('rgbd_image',  '/rgbd_image0'),
+                ('rgbd_image2', '/rgbd_image1'),
+            ],
         ),
 
         Node(
@@ -81,20 +104,29 @@ def generate_launch_description():
 
         # Topic Arguments (Change default_value to match your sim if you want)
         DeclareLaunchArgument(
-            'rgb_topic', default_value='/camera/RGB_image_raw/front',
-            description='Topic for the raw RGB image'),
+            'rgb_topic_front', default_value='/camera/RGB_image_raw/front',
+            description='Topic for the raw RGB image,front camera'),
             
         DeclareLaunchArgument(
-            'depth_topic', default_value='/camera/depth_image_raw/front',
-            description='Topic for the depth image'),
+            'depth_topic_front', default_value='/camera/depth_image_raw/front',
+            description='Topic for the depth image,front camera'),
 
         DeclareLaunchArgument(
-            'camera_info_topic', default_value='/camera_info_front',
-            description='Topic for the camera info'),
+            'camera_info_topic_front', default_value='/camera_info_front',
+            description='Topic for the camera info,front camera'),
 
         DeclareLaunchArgument(
             'frame_id', default_value='base_link',
             description='The TF frame of the camera (Optical frame, Z-forward)'),
+        DeclareLaunchArgument(
+            'rgb_topic_down', default_value='/camera/RGB_image_raw/down',
+            description='Topic for the raw RGB image,down camera'),
+        DeclareLaunchArgument(
+            'depth_topic_down', default_value='/camera/depth_image_raw/down',
+            description='Topic for the depth image,down camera'),
+        DeclareLaunchArgument(
+            'camera_info_topic_down', default_value='/camera_info_down',
+            description='Topic for the camera info,down camera'),
 
         OpaqueFunction(function=launch_setup)
     ])

--- a/src/hydrogen/launch/model.launch.py
+++ b/src/hydrogen/launch/model.launch.py
@@ -20,6 +20,7 @@ def generate_launch_description():
     
     worlds_path = os.path.join(pkg_share, 'worlds')
     model_path = os.path.join(pkg_share, 'model')
+    rviz_config_path = os.path.join(pkg_share, 'parameters','config.rviz')
 
     install_dir = os.path.dirname(pkg_share)
 
@@ -120,6 +121,14 @@ def generate_launch_description():
     	name='allocation_matrix',
     	output='screen',
     )    
+    rviz2 = Node(
+        package='rviz2',
+        executable='rviz2',
+        name='rviz2',
+        output='screen',
+        arguments=['-d', rviz_config_path],
+        parameters=[{'use_sim_time': True}]
+    )
 
     # ---------------- Launch Description ----------------
     ld = LaunchDescription()
@@ -138,7 +147,7 @@ def generate_launch_description():
     ld.add_action(spawn_robot)
     ld.add_action(ros_gz_bridge)
     ld.add_action(thruster_allocator)
-    
+    ld.add_action(rviz2)
 
     return ld
 

--- a/src/hydrogen/model/main_frame.xacro
+++ b/src/hydrogen/model/main_frame.xacro
@@ -8,7 +8,7 @@
     <link name="hydrogen_frame">
       <inertial>
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
-        <mass value="45.0"/>
+        <mass value="112.0"/>
         <inertia
           ixx="0.2276"
           ixy="-0.004544"
@@ -19,7 +19,7 @@
       </inertial>
 
       <visual>
-      <origin xyz="0.008 0.0 0.0" rpy="0 0 1.57"/>
+        <origin xyz="0.008 0.0 0.0" rpy="0 0 1.57"/>
         <geometry>
           <mesh
             filename="file://$(find hydrogen)/meshes/auv.stl"
@@ -30,15 +30,15 @@
         </material>
       </visual>
 
+      <!-- FIXED: height 0.3 -> 0.37 for sufficient buoyancy at 112 kg -->
       <collision name="hydrogen_frame_collision">
         <origin xyz="-0.00013 0.0 0.15" rpy="0 0 0"/>
         <geometry>
-          <box size="0.75 0.55 0.3"/>
+          <box size="0.75 0.55 0.37"/>
         </geometry>
       </collision>
     </link>
 
-    <!-- Fixed joint -->
     <joint name="base_link_joint" type="fixed">
       <parent link="base_link"/>
       <child link="hydrogen_frame"/>
@@ -55,19 +55,6 @@
       </sensor>
     </gazebo>
 
-    <!-- Absolute depth sensor (optional) -->
-    <!--
-    <gazebo reference="base_link">
-      <plugin
-        filename="libauv_absolute_depth.so"
-        name="auv_absolute_depth">
-        <reference_z>0.0</reference_z>
-        <topic>/altimeter</topic>
-      </plugin>
-    </gazebo>
-    -->
-
   </xacro:macro>
 
 </robot>
-


### PR DESCRIPTION
1.  add dual-camera support to RTAB-Map launch
- Add second ZED camera (down-facing) with separate rgbd_sync node
- Refactor single shared remappings into per-camera remappings and parameters
- Set rgbd_cameras=2 and Vis/EstimationType=0 for multi-camera SLAM
- Route cameras to /rgbd_image0 and /rgbd_image1 topics
- Split parameters into base_parameters and rtabmap_parameters

2. launch RViz2 with custom config on simulation start
- Add RViz2 node with config loaded from parameters/config.rviz

 3.add 3D coordinate visualization to ROI depth fusion node
- display odom frame coordinates (x, y, z) on detection image for each detected object
